### PR TITLE
dbのエンコードの変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ build:
 run:
 	docker-compose up
 
+.PHONY: down
+down:
+	docker-compose down
+
 .PHONY: db-create
 db-create:
 	docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     build:
       context: ./docker/containers/db
     volumes:
+      - ./docker/containers/db/my.cnf:/etc/mysql/conf.d/my.cnf
       - db_data:/var/lib/mysql
     ports: 
       - 3316:3306

--- a/docker/bin/create-db.sh
+++ b/docker/bin/create-db.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 docker-compose run --rm db mysql -h db -u root 1> /dev/null << EOF
-CREATE DATABASE examin;
+CREATE DATABASE examin DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_general_ci;
 EOF
 
 if [ $? = 0 ]; then

--- a/docker/containers/db/my.cnf
+++ b/docker/containers/db/my.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+
+[client]
+default-character-set=utf8mb4

--- a/docker/containers/db/my.cnf
+++ b/docker/containers/db/my.cnf
@@ -1,6 +1,6 @@
 [mysqld]
 character-set-server=utf8mb4
-collation-server=utf8mb4_unicode_ci
+collation-server=utf8mb4_general_ci
 
 [client]
 default-character-set=utf8mb4

--- a/infrastructure/datastore/connection.go
+++ b/infrastructure/datastore/connection.go
@@ -34,7 +34,7 @@ func dbConfig() string {
 	port := env.DBPort
 	database := env.DBName
 
-	connect := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8&parseTime=True&loc=Local",
+	connect := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local",
 		username,
 		password,
 		host,


### PR DESCRIPTION
## 目的

DBのエンコードの変更

## やったこと

* [x] DBのエンコードの変更

## マージ後に必要な操作

### データベースを未作成の場合

> $ make db-create  
> $ make db-migrate

### すでにデータベースを作成している場合

* コンテナに入る

> $ docker-compose run --rm db mysql -h db -u root

* データベースのエンコードの変更

> mysql> alter database examin character set utf8mb4 collate utf8mb4_general_ci;

* 既存テーブル ( users ) のエンコードの変更

> mysql> alter table examin.users default character set utf8mb4;

## その他

データベースのエンコードが `utf8` だったので日本語での登録ができなかったので、エンコードを `utf8mb4` に変更しました.
