### PR TITLE
Feature/teachers/tags/create

### DIFF
--- a/application/usecase/t_problem_usecase.go
+++ b/application/usecase/t_problem_usecase.go
@@ -7,29 +7,46 @@ import (
 
 // TProblemUsecase - 講師用の 問題集ユースケース
 type TProblemUsecase interface {
-	CreateProblem(title, content string, userID uint, tags []string) (*model.Problem, error)
+	CreateProblem(title, content string, userID uint, tags []string) (*model.Problem, []*model.Tag, error)
 }
 
 type tProblemUsecase struct {
-	service service.TProblemService
+	tProblemService service.TProblemService
+	tTagService     service.TTagService
 }
 
 // NewTProblemUsecase - tProblemUsecase の生成
-func NewTProblemUsecase(s service.TProblemService) TProblemUsecase {
-	return &tProblemUsecase{s}
+func NewTProblemUsecase(ps service.TProblemService, ts service.TTagService) TProblemUsecase {
+	return &tProblemUsecase{ps, ts}
 }
 
-func (u *tProblemUsecase) CreateProblem(title, content string, userID uint, tags []string) (*model.Problem, error) {
+func (u *tProblemUsecase) CreateProblem(title, content string, userID uint, tags []string) (*model.Problem, []*model.Tag, error) {
+	// 問題集の登録
 	problem := &model.Problem{
 		Title:   title,
 		Content: content,
 		UserID:  userID,
 	}
 
-	createdProblem, err := u.service.CreateProblem(problem)
+	createdProblem, err := u.tProblemService.CreateProblem(problem)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return createdProblem, nil
+	// 問題集のタグを登録
+	createdTags := make([]*model.Tag, 0, 4)
+	for _, v := range tags {
+		tag := &model.Tag{Content: v}
+
+		createdTag, err := u.tTagService.CreateTag(tag)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		createdTags = append(createdTags, createdTag)
+	}
+
+	// TODO: 問題集とタグを関連付け
+
+	return createdProblem, createdTags, nil
 }

--- a/application/usecase/t_problem_usecase.go
+++ b/application/usecase/t_problem_usecase.go
@@ -7,7 +7,7 @@ import (
 
 // TProblemUsecase - 講師用の 問題集ユースケース
 type TProblemUsecase interface {
-	CreateProblem(title, content string, userID uint) (*model.Problem, error)
+	CreateProblem(title, content string, userID uint, tags []string) (*model.Problem, error)
 }
 
 type tProblemUsecase struct {
@@ -19,7 +19,7 @@ func NewTProblemUsecase(s service.TProblemService) TProblemUsecase {
 	return &tProblemUsecase{s}
 }
 
-func (u *tProblemUsecase) CreateProblem(title, content string, userID uint) (*model.Problem, error) {
+func (u *tProblemUsecase) CreateProblem(title, content string, userID uint, tags []string) (*model.Problem, error) {
 	problem := &model.Problem{
 		Title:   title,
 		Content: content,

--- a/application/usecase/t_problem_usecase.go
+++ b/application/usecase/t_problem_usecase.go
@@ -51,7 +51,7 @@ func (u *tProblemUsecase) CreateProblem(title, content string, userID uint, tags
 			TagID:     createdTag.Base.ID,
 		}
 
-		_, err := u.tProblemsTagService.CreateProblemsTag(problemsTag)
+		_, err = u.tProblemsTagService.CreateProblemsTag(problemsTag)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/application/usecase/t_problem_usecase.go
+++ b/application/usecase/t_problem_usecase.go
@@ -35,13 +35,10 @@ func (u *tProblemUsecase) CreateProblem(title, content string, userID uint, tags
 	}
 
 	// 問題集のタグを登録
-	// TODO: 全てのタグを取得
 	createdTags := make([]*model.Tag, 0, 4)
 	for _, v := range tags {
 		tag := &model.Tag{Content: v}
 
-		// TODO: タグがすでに存在する場合、タグ情報の取得
-		// TODO: そうでない場合は、タグを登録する
 		createdTag, err := u.tTagService.CreateTag(tag)
 		if err != nil {
 			return nil, nil, err

--- a/application/usecase/t_problem_usecase.go
+++ b/application/usecase/t_problem_usecase.go
@@ -37,6 +37,7 @@ func (u *tProblemUsecase) CreateProblem(title, content string, userID uint, tags
 	// 問題集のタグを登録
 	createdTags := make([]*model.Tag, 0, 4)
 	for _, v := range tags {
+		// タグの登録と取得
 		tag := &model.Tag{Content: v}
 
 		createdTag, err := u.tTagService.CreateTag(tag)
@@ -44,20 +45,18 @@ func (u *tProblemUsecase) CreateProblem(title, content string, userID uint, tags
 			return nil, nil, err
 		}
 
-		createdTags = append(createdTags, createdTag)
-	}
-
-	// 問題集とタグを関連付け
-	for _, v := range createdTags {
+		// 問題集とタグを関連付け
 		problemsTag := &model.ProblemsTag{
 			ProblemID: createdProblem.Base.ID,
-			TagID:     v.Base.ID,
+			TagID:     createdTag.Base.ID,
 		}
 
 		_, err := u.tProblemsTagService.CreateProblemsTag(problemsTag)
 		if err != nil {
 			return nil, nil, err
 		}
+
+		createdTags = append(createdTags, createdTag)
 	}
 
 	return createdProblem, createdTags, nil

--- a/application/usecase/t_problem_usecase_test.go
+++ b/application/usecase/t_problem_usecase_test.go
@@ -32,7 +32,7 @@ func (m *TProblemServiceMock) CreateProblem(problem *model.Problem) (*model.Prob
 func TestTProblemUsecase_CreateProblem(t *testing.T) {
 	target := NewTProblemUsecase(&TProblemServiceMock{})
 	want := createdProblemMock
-	got, err := target.CreateProblem("title", "content", 1)
+	got, err := target.CreateProblem("title", "content", 1, ["aaa", "bbb", "ccc"])
 
 	if err != nil {
 		t.Fatalf("error: %v", err)

--- a/application/usecase/t_problem_usecase_test.go
+++ b/application/usecase/t_problem_usecase_test.go
@@ -28,6 +28,16 @@ var (
 		},
 		Content: "content",
 	}
+
+	createdProblemsTagMock = &model.ProblemsTag{
+		Base: model.Base{
+			ID:        1,
+			CreatedAt: time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		ProblemID: createdProblemMock.Base.ID,
+		TagID:     createdTagMock.Base.ID,
+	}
 )
 
 type TProblemServiceMock struct {
@@ -36,6 +46,14 @@ type TProblemServiceMock struct {
 func (m *TProblemServiceMock) CreateProblem(problem *model.Problem) (*model.Problem, error) {
 	createdProblem := createdProblemMock
 	return createdProblem, nil
+}
+
+type TProblemsTagServiceMock struct {
+}
+
+func (m *TProblemsTagServiceMock) CreateProblemsTag(problemsTag *model.ProblemsTag) (*model.ProblemsTag, error) {
+	createdProblemsTag := createdProblemsTagMock
+	return createdProblemsTag, nil
 }
 
 type TTagServiceMock struct {
@@ -47,7 +65,7 @@ func (m *TTagServiceMock) CreateTag(tag *model.Tag) (*model.Tag, error) {
 }
 
 func TestTProblemUsecase_CreateProblem(t *testing.T) {
-	target := NewTProblemUsecase(&TProblemServiceMock{}, &TTagServiceMock{})
+	target := NewTProblemUsecase(&TProblemServiceMock{}, &TProblemsTagServiceMock{}, &TTagServiceMock{})
 	wantProblem := createdProblemMock
 	wantTags := []*model.Tag{createdTagMock, createdTagMock, createdTagMock}
 	gotProblem, gotTags, err := target.CreateProblem("title", "content", 1, []string{"aaa", "bbb", "ccc"})

--- a/application/usecase/t_problem_usecase_test.go
+++ b/application/usecase/t_problem_usecase_test.go
@@ -19,6 +19,15 @@ var (
 		Content: "content",
 		UserID:  1,
 	}
+
+	createdTagMock = &model.Tag{
+		Base: model.Base{
+			ID:        1,
+			CreatedAt: time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		Content: "content",
+	}
 )
 
 type TProblemServiceMock struct {
@@ -29,16 +38,29 @@ func (m *TProblemServiceMock) CreateProblem(problem *model.Problem) (*model.Prob
 	return createdProblem, nil
 }
 
+type TTagServiceMock struct {
+}
+
+func (m *TTagServiceMock) CreateTag(tag *model.Tag) (*model.Tag, error) {
+	createdTag := createdTagMock
+	return createdTag, nil
+}
+
 func TestTProblemUsecase_CreateProblem(t *testing.T) {
-	target := NewTProblemUsecase(&TProblemServiceMock{})
-	want := createdProblemMock
-	got, err := target.CreateProblem("title", "content", 1, ["aaa", "bbb", "ccc"])
+	target := NewTProblemUsecase(&TProblemServiceMock{}, &TTagServiceMock{})
+	wantProblem := createdProblemMock
+	wantTags := []*model.Tag{createdTagMock, createdTagMock, createdTagMock}
+	gotProblem, gotTags, err := target.CreateProblem("title", "content", 1, []string{"aaa", "bbb", "ccc"})
 
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
 
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("want %#v, but %#v", want, got)
+	if !reflect.DeepEqual(gotProblem, wantProblem) {
+		t.Fatalf("want %#v, but %#v", wantProblem, gotProblem)
+	}
+
+	if !reflect.DeepEqual(gotTags, wantTags) {
+		t.Fatalf("want %#v, but %#v", wantTags, gotTags)
 	}
 }

--- a/domain/model/problems_tag.go
+++ b/domain/model/problems_tag.go
@@ -1,0 +1,8 @@
+package model
+
+// ProblemsTag ー 問題集とタグの関連付け用 中間モデル
+type ProblemsTag struct {
+	Base
+	ProblemID uint `json:"problem_id"`
+	TagID     uint `json:"tag_id"`
+}

--- a/domain/model/tag.go
+++ b/domain/model/tag.go
@@ -3,5 +3,5 @@ package model
 // Tag - タグ モデル
 type Tag struct {
 	Base
-	Content string `json:"content"`
+	Content string `json:"content" gorm:"unique;not null"`
 }

--- a/domain/model/tag.go
+++ b/domain/model/tag.go
@@ -1,0 +1,7 @@
+package model
+
+// Tag - タグ モデル
+type Tag struct {
+	Base
+	Content string `json:"content"`
+}

--- a/domain/repository/t_problems_tag_respository.go
+++ b/domain/repository/t_problems_tag_respository.go
@@ -1,0 +1,10 @@
+package repository
+
+import (
+	"github.com/16francs/examin_go/domain/model"
+)
+
+// TProblemsTagRepository - 講師向け 問題集タグ 中間モデルのデータベース操作
+type TProblemsTagRepository interface {
+	CreateProblemsTag(problemsTag *model.ProblemsTag) (*model.ProblemsTag, error)
+}

--- a/domain/repository/t_tag_repository.go
+++ b/domain/repository/t_tag_repository.go
@@ -1,0 +1,8 @@
+package repository
+
+import "github.com/16francs/examin_go/domain/model"
+
+// TTagRepository - 講師向け タグ モデルのデータベース操作
+type TTagRepository interface {
+	CreateTag(tag *model.Tag) (*model.Tag, error)
+}

--- a/domain/repository/user_repository.go
+++ b/domain/repository/user_repository.go
@@ -6,5 +6,6 @@ import (
 
 type UserRepository interface {
 	Create(user *model.User) error
+	FindByID(id uint) (*model.User, error)
 	FindByLoginID(LoginID string) (*model.User, error)
 }

--- a/domain/service/t_problems_tag_service.go
+++ b/domain/service/t_problems_tag_service.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"github.com/16francs/examin_go/domain/model"
+	"github.com/16francs/examin_go/domain/repository"
+)
+
+// TProblemsTagService - 講師向け 問題集タグ 中間モデルの操作
+type TProblemsTagService interface {
+	CreateProblemsTag(problemsTag *model.ProblemsTag) (*model.ProblemsTag, error)
+}
+
+type tProblemsTagService struct {
+	repository repository.TProblemsTagRepository
+}
+
+// NewTProblemsTagService - tProblemsTagService の生成
+func NewTProblemsTagService(r repository.TProblemsTagRepository) TProblemsTagService {
+	return &tProblemsTagService{r}
+}
+
+func (s *tProblemsTagService) CreateProblemsTag(problemsTag *model.ProblemsTag) (*model.ProblemsTag, error) {
+	createdProblemsTag, err := s.repository.CreateProblemsTag(problemsTag)
+	if err != nil {
+		return nil, err
+	}
+
+	return createdProblemsTag, nil
+}

--- a/domain/service/t_problems_tag_service_test.go
+++ b/domain/service/t_problems_tag_service_test.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/16francs/examin_go/domain/model"
+)
+
+var (
+	problemsTagMock = &model.ProblemsTag{
+		ProblemID: 1,
+		TagID:     1,
+	}
+
+	createdProblemsTagMock = &model.ProblemsTag{
+		Base: model.Base{
+			ID:        1,
+			CreatedAt: time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		ProblemID: 1,
+		TagID:     1,
+	}
+)
+
+type TProblemsTagRepositoryMock struct {
+}
+
+func (m *TProblemsTagRepositoryMock) CreateProblemsTag(problemsTag *model.ProblemsTag) (*model.ProblemsTag, error) {
+	createdProblemsTag := createdProblemsTagMock
+	return createdProblemsTag, nil
+}
+
+func TestProblemsTagService_CreateProblemsTag(t *testing.T) {
+	target := NewTProblemsTagService(&TProblemsTagRepositoryMock{})
+	want := createdProblemsTagMock
+	got, err := target.CreateProblemsTag(problemsTagMock)
+
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("want %#v, but %#v", want, got)
+	}
+}

--- a/domain/service/t_tag_service.go
+++ b/domain/service/t_tag_service.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"github.com/16francs/examin_go/domain/model"
+	"github.com/16francs/examin_go/domain/repository"
+)
+
+// TTagService - 講師向け タグ モデルの操作
+type TTagService interface {
+	CreateTag(tag *model.Tag) (*model.Tag, error)
+}
+
+type tTagService struct {
+	repository repository.TTagRepository
+}
+
+// NewTTagService - tTagService の生成
+func NewTTagService(r repository.TTagRepository) TTagService {
+	return &tTagService{r}
+}
+
+func (s *tTagService) CreateTag(tag *model.Tag) (*model.Tag, error) {
+	createdTag, err := s.repository.CreateTag(tag)
+	if err != nil {
+		return nil, err
+	}
+
+	return createdTag, nil
+}

--- a/domain/service/t_tag_service_test.go
+++ b/domain/service/t_tag_service_test.go
@@ -34,7 +34,7 @@ func (m *TTagRepositoryMock) CreateTag(tag *model.Tag) (*model.Tag, error) {
 func TestTagService_CreateTag(t *testing.T) {
 	target := NewTTagService(&TTagRepositoryMock{})
 	want := createdTagMock
-	got, err := target.CreateTag(TagMock)
+	got, err := target.CreateTag(tagMock)
 
 	if err != nil {
 		t.Fatalf("error: %v", err)

--- a/domain/service/t_tag_service_test.go
+++ b/domain/service/t_tag_service_test.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/16francs/examin_go/domain/model"
+)
+
+var (
+	tagMock = &model.Tag{
+		Content: "tag",
+	}
+
+	createdTagMock = &model.Tag{
+		Base: model.Base{
+			ID:        1,
+			CreatedAt: time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		Content: "tag",
+	}
+)
+
+type TTagRepositoryMock struct {
+}
+
+func (m *TTagRepositoryMock) CreateTag(tag *model.Tag) (*model.Tag, error) {
+	createdTag := createdTagMock
+	return createdTag, nil
+}
+
+func TestTagService_CreateTag(t *testing.T) {
+	target := NewTTagService(&TTagRepositoryMock{})
+	want := createdTagMock
+	got, err := target.CreateTag(TagMock)
+
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("want %#v, but %#v", want, got)
+	}
+}

--- a/infrastructure/datastore/migrate/migrate.go
+++ b/infrastructure/datastore/migrate/migrate.go
@@ -14,5 +14,6 @@ func main() {
 	// db.AutoMifrate(&model.User{}) <- User テーブルの作成
 	db.AutoMigrate(&model.Problem{})
 	db.AutoMigrate(&model.Tag{})
+	db.AutoMigrate(&model.ProblemsTag{})
 	db.AutoMigrate(&model.User{})
 }

--- a/infrastructure/datastore/migrate/migrate.go
+++ b/infrastructure/datastore/migrate/migrate.go
@@ -13,5 +13,6 @@ func main() {
 	// テーブルの作成
 	// db.AutoMifrate(&model.User{}) <- User テーブルの作成
 	db.AutoMigrate(&model.Problem{})
+	db.AutoMigrate(&model.Tag{})
 	db.AutoMigrate(&model.User{})
 }

--- a/infrastructure/datastore/t_problems_tag_repository.go
+++ b/infrastructure/datastore/t_problems_tag_repository.go
@@ -1,0 +1,22 @@
+package datastore
+
+import (
+	"github.com/16francs/examin_go/domain/model"
+	"github.com/16francs/examin_go/domain/repository"
+)
+
+type tProblemsTagRepository struct {
+}
+
+// NewTProblemsTagRepository - tProblemsTagRepository の生成
+func NewTProblemsTagRepository() repository.TProblemsTagRepository {
+	return &tProblemsTagRepository{}
+}
+
+func (r *tProblemsTagRepository) CreateProblemsTag(problemsTag *model.ProblemsTag) (*model.ProblemsTag, error) {
+	db := Connect()
+	defer db.Close()
+
+	err := db.Create(&problemsTag).Error
+	return problemsTag, err
+}

--- a/infrastructure/datastore/t_tag_repository.go
+++ b/infrastructure/datastore/t_tag_repository.go
@@ -13,7 +13,7 @@ func NewTTagRepository() repository.TTagRepository {
 	return &tTagRepository{}
 }
 
-func (r *tTagRepository) CreateTag(tag *model.Tag) (*modek.Tag, error) {
+func (r *tTagRepository) CreateTag(tag *model.Tag) (*model.Tag, error) {
 	db := Connect()
 	defer db.Close()
 

--- a/infrastructure/datastore/t_tag_repository.go
+++ b/infrastructure/datastore/t_tag_repository.go
@@ -1,0 +1,22 @@
+package datastore
+
+import (
+	"github.com/16francs/examin_go/domain/model"
+	"github.com/16francs/examin_go/domain/repository"
+)
+
+type tTagRepository struct {
+}
+
+// NewTTagRepository - tTagRepository の生成
+func NewTTagRepository() repository.TTagRepository {
+	return &tTagRepository{}
+}
+
+func (r *tTagRepository) CreateTag(tag *model.Tag) (*modek.Tag, error) {
+	db := Connect()
+	defer db.Close()
+
+	err := db.Create(&tag).Error
+	return tag, err
+}

--- a/infrastructure/datastore/t_tag_repository.go
+++ b/infrastructure/datastore/t_tag_repository.go
@@ -17,6 +17,6 @@ func (r *tTagRepository) CreateTag(tag *model.Tag) (*model.Tag, error) {
 	db := Connect()
 	defer db.Close()
 
-	err := db.Create(&tag).Error
+	err := db.FirstOrCreate(&tag, tag).Error
 	return tag, err
 }

--- a/infrastructure/datastore/user_repository.go
+++ b/infrastructure/datastore/user_repository.go
@@ -21,6 +21,15 @@ func (u *userRepository) Create(user *model.User) error {
 	return err
 }
 
+func (u *userRepository) FindByID(id uint) (*model.User, error) {
+	db := Connect()
+	defer db.Close()
+
+	user := &model.User{}
+	err := db.Where("id = ?", id).First(&user).Error
+	return user, err
+}
+
 func (u *userRepository) FindByLoginID(loginID string) (*model.User, error) {
 	db := Connect()
 	defer db.Close()

--- a/interface/handler/t_problem_handler.go
+++ b/interface/handler/t_problem_handler.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"net/http"
 
+	"github.com/16francs/examin_go/interface/middleware"
+
 	"github.com/16francs/examin_go/application/usecase"
 	"github.com/16francs/examin_go/interface/request"
 	"github.com/16francs/examin_go/interface/response"
@@ -42,18 +44,26 @@ func (h *tProblemHandler) CreateProblem(c *gin.Context) {
 		return
 	}
 
-	// レスポンスの整形
+	// ログイン講師情報の取得
+	authUser, err := middleware.GetAuthUser(uint(userID))
+	if err != nil {
+		ServerError(c)
+		return
+	}
+
+	// 問題集タグの整形
 	tagContents := make([]string, 0, 4)
 	for _, v := range tags {
 		tagContents = append(tagContents, v.Content)
 	}
 
+	// レスポンスの作成
 	response := &response.TCreateProblem{
 		ID:          problem.Base.ID,
 		Title:       problem.Title,
 		Content:     problem.Content,
 		Tags:        tagContents,
-		TeacherName: "taecher", // TODO: ログイン情報から取得
+		TeacherName: authUser.Name,
 		CreatedAt:   problem.Base.CreatedAt,
 		UpdatedAt:   problem.Base.UpdatedAt,
 	}

--- a/interface/handler/t_problem_handler.go
+++ b/interface/handler/t_problem_handler.go
@@ -35,7 +35,7 @@ func (h *tProblemHandler) CreateProblem(c *gin.Context) {
 		return
 	}
 
-	response, err := h.usecase.CreateProblem(request.Title, request.Content, uint(userID))
+	response, err := h.usecase.CreateProblem(request.Title, request.Content, uint(userID), request.Tags)
 	if err != nil {
 		ServerError(c)
 		return

--- a/interface/handler/t_problem_handler.go
+++ b/interface/handler/t_problem_handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/16francs/examin_go/application/usecase"
 	"github.com/16francs/examin_go/interface/request"
+	"github.com/16francs/examin_go/interface/response"
 	"github.com/gin-gonic/gin"
 )
 
@@ -35,11 +36,26 @@ func (h *tProblemHandler) CreateProblem(c *gin.Context) {
 		return
 	}
 
-	response, err := h.usecase.CreateProblem(request.Title, request.Content, uint(userID), request.Tags)
+	problem, tags, err := h.usecase.CreateProblem(request.Title, request.Content, uint(userID), request.Tags)
 	if err != nil {
 		ServerError(c)
 		return
 	}
 
+	// レスポンスの整形
+	tagContents := make([]string, 0, 4)
+	for _, v := range tags {
+		tagContents = append(tagContents, v.Content)
+	}
+
+	response := &response.TCreateProblem{
+		ID:          problem.Base.ID,
+		Title:       problem.Title,
+		Content:     problem.Content,
+		Tags:        tagContents,
+		TeacherName: "taecher", // TODO: ログイン情報から取得
+		CreatedAt:   problem.Base.CreatedAt,
+		UpdatedAt:   problem.Base.UpdatedAt,
+	}
 	c.JSON(http.StatusCreated, response)
 }

--- a/interface/middleware/auth.go
+++ b/interface/middleware/auth.go
@@ -3,8 +3,22 @@ package middleware
 import (
 	"net/http"
 
+	"github.com/16francs/examin_go/domain/model"
+	"github.com/16francs/examin_go/infrastructure/datastore"
+
 	"github.com/gin-gonic/gin"
 )
+
+// GetAuthUser - IDからログインユーザー情報を取得
+func GetAuthUser(userID uint) (*model.User, error) {
+	userRepository := datastore.NewUserRepository()
+	user, err := userRepository.FindByID(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}
 
 /*
 	jwt-tokenを検証する

--- a/interface/request/t_problem_request.go
+++ b/interface/request/t_problem_request.go
@@ -2,6 +2,7 @@ package request
 
 // TCreateProblem - 講師向けの問題集作成のリクエスト
 type TCreateProblem struct {
-	Title   string `json:"title" binding:"required,max=31"`
-	Content string `json:"content" binding:"required,max=63"`
+	Title   string   `json:"title" binding:"required,max=31"`
+	Content string   `json:"content" binding:"required,max=63"`
+	Tags    []string `json:"tags" binding:"lt=5"`
 }

--- a/interface/response/t_problem_response.go
+++ b/interface/response/t_problem_response.go
@@ -1,0 +1,14 @@
+package response
+
+import "time"
+
+// TCreateProblem - 講師向けの問題集作成のリクエスト
+type TCreateProblem struct {
+	ID          uint      `json:"id"`
+	Title       string    `json:"title"`
+	Content     string    `json:"content"`
+	Tags        []string  `json:"tags"`
+	TeacherName string    `json:"teacher_name"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -38,9 +38,12 @@ func NewRegistry() Registry {
 	tTagRepository := datastore.NewTTagRepository()
 	tTagService := service.NewTTagService(tTagRepository)
 
+	tProblemsTagRepository := datastore.NewTProblemsTagRepository()
+	tProblemsTagService := service.NewTProblemsTagService(tProblemsTagRepository)
+
 	tProblemRepository := datastore.NewTProblemRepository()
 	tProblemService := service.NewTProblemService(tProblemRepository)
-	tProblemUsecase := usecase.NewTProblemUsecase(tProblemService, tTagService)
+	tProblemUsecase := usecase.NewTProblemUsecase(tProblemService, tProblemsTagService, tTagService)
 	tProblemHandler := handler.NewTProblemHandler(tProblemUsecase)
 
 	tTeacherRepository := datastore.NewTTeacherRepository()

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -35,9 +35,12 @@ func NewRegistry() Registry {
 	authUsecase := usecase.NewAuthUsecase(authService)
 	authHandler := handler.NewAuthHandler(authUsecase)
 
+	tTagRepository := datastore.NewTTagRepository()
+	tTagService := service.NewTTagService(tTagRepository)
+
 	tProblemRepository := datastore.NewTProblemRepository()
 	tProblemService := service.NewTProblemService(tProblemRepository)
-	tProblemUsecase := usecase.NewTProblemUsecase(tProblemService)
+	tProblemUsecase := usecase.NewTProblemUsecase(tProblemService, tTagService)
 	tProblemHandler := handler.NewTProblemHandler(tProblemUsecase)
 
 	tTeacherRepository := datastore.NewTTeacherRepository()


### PR DESCRIPTION
## 目的

講師向けの問題集登録APIの実装

## やったこと

* [x] タグモデルの作成
* [x] タグ登録処理の実装
* [x] 講師向けの問題集登録APIのレスポンスの作成
* [x] 問題集とタグの中間テーブルモデルの作成 <- モデルとして必要かわからんけど
* [x] 問題集とタグの関連付け処理の実装
* [x] レスポンスの `teacher_name` へのログイン情報の付加
* [x] テストの修正
* [x] テストの追加

## マージ後に必要な操作

* データベースへのテーブル追加

> $ make db-migrate

## その他

記述量が多くなってきたので、一旦プルリク出します。残りの内容は、別のプルリクで実装します。  
特にレビューいただきたい箇所としては、

```
* `interface/response` 内の記述方法
* `t_problem_handler.go` での レスポンス整形の処理 の記述位置
```

あたりお願いします。